### PR TITLE
Add optional status LED

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can configure LED power pin in the `platformio.ini` to power off LEDs while 
 Review the comments at the top of the file:
 * `LED_POWER_PIN` - This is the data pin external power control
 * `LED_POWER_INVERT` - This inverts the output of the exernal power control pin. If set to `false`, the pin state will be low when the relay is turned off. If set to `true`, the pin state will be high when the relay is off. If not defined, default is `false`.
+* `STATUS_LED_PIN` - Optional pin for a status LED indicating serial activity. Example: `-DSTATUS_LED_PIN=15`
 
 Note: For static color configuration this mechanism will turn off the LEDs. To counter this enable "Continuous Output" in HyperHDR "Smoothing" module. For esp32 and relay control, you may want to disable the "Handshake" option in the Adalight HyperHDR driver to avoid the relay immediately shutting down when resetting the device while initializing the connection.
 

--- a/include/main.h
+++ b/include/main.h
@@ -35,6 +35,7 @@
 #include "statistics.h"
 #include "base.h"
 #include "framestate.h"
+#include "statusled.h"
 
 /**
  * @brief separete thread on core 1 for handling serial communication using cyclic buffer
@@ -62,10 +63,14 @@ bool serialTaskHandler()
 	}
 
 #if defined(LED_POWER_PIN)
-	powerControl.update(incomingSize > 0);
+        powerControl.update(incomingSize > 0);
 #endif
 
-	return (incomingSize > 0);
+#if defined(STATUS_LED_PIN)
+        statusLed.update(false);
+#endif
+
+        return (incomingSize > 0);
 }
 
 void updateMainStatistics(unsigned long currentTime, unsigned long deltaTime, bool hasData)
@@ -270,7 +275,10 @@ void processData()
 			{
 				statistics.increaseGood();
 
-				base.renderLeds(true);
+                                base.renderLeds(true);
+#if defined(STATUS_LED_PIN)
+                                statusLed.update(true);
+#endif
 
 				#ifdef NEOPIXEL_RGBW
 					// if received the calibration data, update it now

--- a/include/statusled.h
+++ b/include/statusled.h
@@ -1,0 +1,58 @@
+#ifndef STATUSLED_H
+#define STATUSLED_H
+
+#ifdef STATUS_LED_PIN
+
+#include <Arduino.h>
+
+class
+{
+        const uint8_t CHANNEL = 7;
+        const uint32_t FREQ = 5000;
+        const uint8_t RESOLUTION = 8;
+        const unsigned long BLINK_TIME = 100;     // ms
+        const unsigned long BLINK_GAP = 100;      // limit to 10 Hz
+        const unsigned long BREATH_STEP = 20;     // ms per brightness step
+
+        unsigned long activeUntil = 0;
+        unsigned long lastBlink = 0;
+        unsigned long lastBreath = 0;
+        int8_t breatheDir = 1;
+        uint8_t breatheValue = 0;
+
+        public:
+                void init()
+                {
+                        ledcSetup(CHANNEL, FREQ, RESOLUTION);
+                        ledcAttachPin(STATUS_LED_PIN, CHANNEL);
+                        breatheValue = 0;
+                        breatheDir = 1;
+                }
+
+                void update(bool hasActivity)
+                {
+                        unsigned long now = millis();
+
+                        if (hasActivity && (now - lastBlink >= BLINK_GAP))
+                        {
+                                lastBlink = now;
+                                activeUntil = now + BLINK_TIME;
+                        }
+
+                        if (now < activeUntil)
+                        {
+                                ledcWrite(CHANNEL, 255);
+                        }
+                        else if (now - lastBreath >= BREATH_STEP)
+                        {
+                                lastBreath = now;
+                                breatheValue += breatheDir;
+                                if (breatheValue == 0 || breatheValue == 255)
+                                        breatheDir = -breatheDir;
+                                ledcWrite(CHANNEL, breatheValue);
+                        }
+                }
+} statusLed;
+
+#endif // STATUS_LED_PIN
+#endif // STATUSLED_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,6 +4,7 @@
 ; CLOCK_PIN = pin/GPIO for the LED strip clock channel, specific [board] section
 ; LED_POWER_PIN = pin/GPIO for external relay power control, it will turn off (low state) if no serial data is received after 5 seconds
 ; LED_POWER_INVERT = if defined: off state is a high signal for the power relay, on state is a low signal
+; STATUS_LED_PIN = pin/GPIO for activity status indicator LED (optional)
 
 ; MULTI-SEGMENT SUPPORT
 ; You can define second segment to handle. Add following parameters (with -D prefix to the build_flags sections).
@@ -89,7 +90,7 @@ lib_deps = https://github.com/awawa-dev/NeoPixelBus.git#HyperSerialESP32
 test_ignore = *
 
 [env:s2_mini_SK6812_RGBW_COLD]
-build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=5 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=5 -DSTATUS_LED_PIN=15 ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_COLD
 
 board = lolin_s2_mini

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 
 #include <Arduino.h>
 #include <NeoPixelBus.h>
+#include "statusled.h"
 
 #if !defined(ARDUINO_LOLIN_S2_MINI) && ESP_ARDUINO_VERSION_MAJOR == 2 && ESP_ARDUINO_VERSION_MINOR ==0 && ESP_ARDUINO_VERSION_PATCH <= 5
     #error "Arduino ESP32 versions 2.0.0-2.0.5 are unsupported."
@@ -204,8 +205,12 @@ void setup()
 	// Init serial port
 	Serial.setRxBufferSize(MAX_BUFFER - 1);
 	Serial.setTimeout(50);
-	Serial.begin(SERIALCOM_SPEED);
-	while (!Serial) continue;
+        Serial.begin(SERIALCOM_SPEED);
+        while (!Serial) continue;
+
+#if defined(STATUS_LED_PIN)
+        statusLed.init();
+#endif
 
 	#if defined(NEOPIXEL_RGBW) || defined(NEOPIXEL_RGB)
 		#ifdef NEOPIXEL_RGBW


### PR DESCRIPTION
## Summary
- add new StatusLed helper class
- show status LED via PWM and optional blink after each frame
- document STATUS_LED_PIN
- set default status LED pin to 15 for s2_mini_SK6812_RGBW_COLD

## Testing
- `platformio --version`
- `pio run -e s2_mini_SK6812_RGBW_COLD` *(fails: Platform Manager unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_684fc913617c832b916c230c00a3eb39