### PR TITLE
Enable status LED during serial wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ You can configure LED power pin in the `platformio.ini` to power off LEDs while 
 Review the comments at the top of the file:
 * `LED_POWER_PIN` - This is the data pin external power control
 * `LED_POWER_INVERT` - This inverts the output of the exernal power control pin. If set to `false`, the pin state will be low when the relay is turned off. If set to `true`, the pin state will be high when the relay is off. If not defined, default is `false`.
-* `STATUS_LED_PIN` - Optional pin for a status LED indicating serial activity. Example: `-DSTATUS_LED_PIN=15`
-  * By default the LED slowly breathes after boot indicating the board is ready and waiting for data
-  * Define `WAIT_FOR_HANDSHAKE` to blink twice every second until the optional handshake frame is received
+* `STATUS_LED_PIN` - Pin for a status LED indicating serial activity. Defaults to `2` on ESP32 boards and `15` on ESP32-S2 boards
+  * After power-up the LED blinks twice per second while waiting for a serial connection
+  * If `WAIT_FOR_HANDSHAKE` is defined (default), it keeps blinking until the handshake frame is received and then switches to a slow breathing pattern
   * During data reception it pulses quickly (brightness rises for ~0.1s) about five times per second
 
 Note: For static color configuration this mechanism will turn off the LEDs. To counter this enable "Continuous Output" in HyperHDR "Smoothing" module. For esp32 and relay control, you may want to disable the "Handshake" option in the Adalight HyperHDR driver to avoid the relay immediately shutting down when resetting the device while initializing the connection.

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,7 @@ lib_deps = https://github.com/awawa-dev/NeoPixelBus.git#HyperSerialESP32
 test_ignore =
 
 [env:SK6812_RGBW_COLD]
-build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=5 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=5 -DSTATUS_LED_PIN=2 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_SK6812_RGBW_COLD
 
 board = esp32dev
@@ -46,7 +46,7 @@ lib_deps = ${esp32.lib_deps}
 test_ignore = ${esp32.test_ignore}
 
 [env:SK6812_RGBW_NEUTRAL]
-build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=5 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=5 -DSTATUS_LED_PIN=2 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_SK6812_RGBW_NEUTRAL
 
 board = esp32dev
@@ -55,7 +55,7 @@ lib_deps = ${esp32.lib_deps}
 test_ignore = ${esp32.test_ignore}
 
 [env:WS281x_RGB]
-build_flags = -DNEOPIXEL_RGB -DDATA_PIN=5 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGB -DDATA_PIN=5 -DSTATUS_LED_PIN=2 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_WS281x_RGB
 
 board = esp32dev
@@ -64,7 +64,7 @@ lib_deps = ${esp32.lib_deps}
 test_ignore = ${esp32.test_ignore}
 
 [env:SPI_APA102_SK9822_HD107]
-build_flags = -DSPILED_APA102 -DDATA_PIN=5 -DCLOCK_PIN=9 ${env.build_flags}
+build_flags = -DSPILED_APA102 -DDATA_PIN=5 -DCLOCK_PIN=9 -DSTATUS_LED_PIN=2 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_SPI_APA102_SK9822_HD107
 
 board = esp32dev
@@ -73,7 +73,7 @@ lib_deps = ${esp32.lib_deps}
 test_ignore = ${esp32.test_ignore}
 
 [env:SPI_WS2801]
-build_flags = -DSPILED_WS2801 -DDATA_PIN=5 -DCLOCK_PIN=9 ${env.build_flags}
+build_flags = -DSPILED_WS2801 -DDATA_PIN=5 -DCLOCK_PIN=9 -DSTATUS_LED_PIN=2 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_SPI_WS2801
 
 board = esp32dev
@@ -90,7 +90,7 @@ lib_deps = https://github.com/awawa-dev/NeoPixelBus.git#HyperSerialESP32
 test_ignore = *
 
 [env:s2_mini_SK6812_RGBW_COLD]
-build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=5 -DSTATUS_LED_PIN=15 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=5 -DSTATUS_LED_PIN=15 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_COLD
 
 board = lolin_s2_mini
@@ -100,7 +100,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SK6812_RGBW_NEUTRAL]
-build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=5 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=5 -DSTATUS_LED_PIN=15 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_NEUTRAL
 
 board = lolin_s2_mini
@@ -110,7 +110,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_WS281x_RGB]
-build_flags = -DNEOPIXEL_RGB -DDATA_PIN=5 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGB -DDATA_PIN=5 -DSTATUS_LED_PIN=15 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_s2_mini_WS281x_RGB
 
 board = lolin_s2_mini
@@ -120,7 +120,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_APA102_SK9822_HD107]
-build_flags = -DSPILED_APA102 -DDATA_PIN=5 -DCLOCK_PIN=9 ${env.build_flags}
+build_flags = -DSPILED_APA102 -DDATA_PIN=5 -DCLOCK_PIN=9 -DSTATUS_LED_PIN=15 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SPI_APA102_SK9822_HD107
 
 board = lolin_s2_mini
@@ -130,7 +130,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_WS2801]
-build_flags = -DSPILED_WS2801 -DDATA_PIN=5 -DCLOCK_PIN=9 ${env.build_flags}
+build_flags = -DSPILED_WS2801 -DDATA_PIN=5 -DCLOCK_PIN=9 -DSTATUS_LED_PIN=15 -DWAIT_FOR_HANDSHAKE ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SPI_WS2801
 
 board = lolin_s2_mini

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,10 +203,9 @@ void setup()
 	bool multicore = true;
 
 	// Init serial port
-	Serial.setRxBufferSize(MAX_BUFFER - 1);
-	Serial.setTimeout(50);
+        Serial.setRxBufferSize(MAX_BUFFER - 1);
+        Serial.setTimeout(50);
         Serial.begin(SERIALCOM_SPEED);
-        while (!Serial) continue;
 
 #if defined(STATUS_LED_PIN)
         #ifdef WAIT_FOR_HANDSHAKE
@@ -215,6 +214,15 @@ void setup()
                 statusLed.init(false);
         #endif
 #endif
+
+        unsigned long serialWaitStart = millis();
+        while (!Serial && (millis() - serialWaitStart) < 5000)
+        {
+#if defined(STATUS_LED_PIN)
+                statusLed.update(false);
+#endif
+                yield();
+        }
 
         lastGoodFrameTime = millis();
 


### PR DESCRIPTION
## Summary
- keep the status LED active while waiting for a serial connection
- document that the LED blinks twice per second until the handshake

## Testing
- `pip install platformio==6.1.11`
- `platformio test` *(fails: Platform Manager: Installing espressif32 @ 6.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_685152d960a4832b93dcadd82eb5f35b