### PR TITLE
Fix status LED breathing before handshake

### DIFF
--- a/include/statusled.h
+++ b/include/statusled.h
@@ -122,14 +122,21 @@ class
                                 return;
                         }
 
-                        if (now - lastBreath >= BREATH_STEP)
+                        if (!waiting)
                         {
-                                lastBreath = now;
-                                breatheValue += breatheDir;
-                                if (breatheValue == 0 || breatheValue == 255)
-                                        breatheDir = -breatheDir;
+                                if (now - lastBreath >= BREATH_STEP)
+                                {
+                                        lastBreath = now;
+                                        breatheValue += breatheDir;
+                                        if (breatheValue == 0 || breatheValue == 255)
+                                                breatheDir = -breatheDir;
+                                }
+                                ledcWrite(CHANNEL, breatheValue);
                         }
-                        ledcWrite(CHANNEL, breatheValue);
+                        else
+                        {
+                                ledcWrite(CHANNEL, 0);
+                        }
                 }
 } statusLed;
 


### PR DESCRIPTION
## Summary
- stop status LED breathing until handshake completes

## Testing
- `platformio test` *(fails: HTTPClientError due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_685167b9e258832bb9900d2b2e3b3631